### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete URL scheme check

### DIFF
--- a/src/middleware/security.js
+++ b/src/middleware/security.js
@@ -12,7 +12,7 @@ export const sanitizeInput = (req, res, next) => {
       return str
         .trim()
         .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '') 
-        .replace(/javascript:/gi, '') 
+        .replace(/(javascript:|data:|vbscript:)/gi, '') 
         .replace(/on\w+\s*=/gi, '') 
         .replace(/[<>]/g, ''); 
     };


### PR DESCRIPTION
Potential fix for [https://github.com/osgioia/node-tracker/security/code-scanning/11](https://github.com/osgioia/node-tracker/security/code-scanning/11)

The function should be enhanced to also catch and remove or block strings containing the `data:` and `vbscript:` URL schemes, much like it does with `javascript:`. The modification should be made within the `sanitizeString` function. Specifically, line 15 should be updated to also strip out (case-insensitively) any occurrences of `data:` and `vbscript:` in addition to `javascript:`.

This can be done by updating the regex in line 15 to:  
`.replace(/(javascript:|data:|vbscript:)/gi, '')`  
No new imports are required, and functionality remains unchanged except for the improved sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
